### PR TITLE
Feature/recent changes filter

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -13,6 +13,7 @@ program
   .option("-o, --output <file>", "Write output to file")
   
   .option("-i, --include <patterns>", "Comma-separated glob patterns for files to include (e.g. \"*.js,*.md\")")
+  .option("-r, --recent [days]", "Only include files modified within the last N days (default: 7)")
   
   .parse(process.argv);
 


### PR DESCRIPTION
## Implement Recent Changes Filter (`--recent` flag)

**Closes #11**

### Summary
This PR implements the `--recent` flag feature that filters and packages only files modified within a specified number of days based on Git commit history. This addresses the need for more focused repository analysis when working with recent changes.

### Changes Made

#### CLI Enhancement (`bin/cli.js`)
- Added `--recent [days]` option with Commander.js
- Short form `-r [days]` support  
- Optional parameter with default value of 7 days
- Updated help documentation

#### Core Logic Implementation (`src/index.js`)
- Integrated recent file filtering into main processing pipeline
- Enhanced output formatting with recent changes section
- Added comprehensive error handling for non-Git repositories
- Updated summary statistics to reflect recent changes context
- Seamless integration with existing `--include` patterns

#### Git Integration (`src/utils.js`)
- Implemented `getRecentlyModifiedFiles()` function
- Git-only approach using `git log --since=YYYY-MM-DD`
- File extraction using `git show --name-only` for each commit
- Proper error handling for Git command failures
- Repository validation before processing

### Feature Usage

**Command Examples:**
```bash
# Default 7 days
repo-packager . --recent

# Custom timeframe  
repo-packager . --recent 3

# Combined with existing filters
repo-packager . --recent 7 --include "*.js,*.md"